### PR TITLE
feat(pge): add override protocol runtime

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "🔱 PGE :: Lunar Mirror scrubbing staged files…"
+npx lint-staged

--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ Install pre-commit hooks to automatically run code quality checks before each co
 pre-commit install
 ```
 
+## 🔱 PGE Override Protocol
+
+This repository now includes a minimal [Primal Genesis Engine override module](pge/) written in TypeScript. It transmits
+incoming signals through declarative policies and watcher primitives to enforce sovereignty at the application edge.
+
+### Run the engine locally
+
+```bash
+npx ts-node pge/run.ts
+```
+
+### Optional: Discord bridge
+
+```bash
+export DISCORD_TOKEN=your_bot_token
+npx ts-node pge/discord-baddie-bridge.ts
+```
+
+Pre-commit hooks are wired through `.husky` to ensure staged files pass linting via `lint-staged`.
+
 ## 📚 Documentation
 
 Full documentation is available at [https://mkworldwide.github.io/Primal-Genesis-Engine-Sovereign/](https://mkworldwide.github.io/Primal-Genesis-Engine-Sovereign/)

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,1 @@
+export default { extends: ["@commitlint/config-conventional"] };

--- a/pge/discord-baddie-bridge.ts
+++ b/pge/discord-baddie-bridge.ts
@@ -1,0 +1,29 @@
+// Discord integration that routes chat messages through the PGE engine.
+// Leverages basic keyword matching to assign input kinds.
+
+import { Client, GatewayIntentBits } from "discord.js";
+import { runPGE } from "./pge";
+import rules from "./override_rules.json";
+
+export async function startDiscordBridge(token: string) {
+  const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent] });
+
+  client.on("messageCreate", async (m) => {
+    if (m.author.bot) return;
+
+    // Map chat into PGE inputs
+    const lower = m.content.toLowerCase();
+    const kind =
+      /panic|fear|scared/.test(lower) ? "fear_signal" :
+      /propaganda|disinfo/.test(lower) ? "disinfo" :
+      /surveil|monitor/.test(lower) ? "surveillance" :
+      "noise";
+
+    const result = runPGE({ kind, level: 3, author: m.author.id, channel: m.channelId }, rules as any);
+    const summary = result.map(r => r.type).join(", ");
+    await m.reply(`🔱 PGE processed: **${summary}** — Sovereignty upheld.`);
+  });
+
+  await client.login(token);
+  console.log("Serafina bridge online.");
+}

--- a/pge/override_rules.json
+++ b/pge/override_rules.json
@@ -1,0 +1,44 @@
+{
+  "PGE_OVERRIDE_DECREE": {
+    "match": { "input.kind": ["shadow_signal", "fear_signal", "surveillance", "black_budget", "psyop"] },
+    "actions": [
+      { "use": "black-sun-core.absorb", "args": { "intensity_from": "input.level" } },
+      { "use": "serpentine.transmute",  "args": { "from": "shadow", "to": "fuel" } },
+      { "use": "lunar-mirror.scrub",    "args": { "strip": ["illusion", "noise"] } },
+      { "use": "echo.normalize",        "args": { "target_resonance": 432 } },
+      { "use": "solar.assert",          "args": { "mantra": "I command stillness, and chaos yields." } },
+      { "use": "crown.route",           "args": { "to": "transparency_dashboard" } }
+    ],
+    "output": "benevolent_artifact"
+  },
+
+  "FEAR_TO_FUEL": {
+    "match": { "input.kind": ["fear_signal", "intimidation_bark"] },
+    "actions": [
+      { "use": "abyssal.ground",   "args": { "depth": "auto" } },
+      { "use": "flame.allocate",   "args": { "to": "resolve_queue", "percent": 33 } },
+      { "use": "martial.posture",  "args": { "mode": "calm-dominance" } }
+    ],
+    "output": "focus_energy"
+  },
+
+  "ILLUSION_TO_SIGNAL": {
+    "match": { "input.kind": ["disinfo", "noise", "panic"] },
+    "actions": [
+      { "use": "shadow.firewall",  "args": { "rule": "drop-falsehood" } },
+      { "use": "lunar-mirror.reflect", "args": { "only": ["verifiable", "useful"] } },
+      { "use": "memory.log",       "args": { "channel": "audit" } }
+    ],
+    "output": "clean_signal"
+  },
+
+  "CONTROL_TO_CONSENT": {
+    "match": { "input.kind": ["surveillance", "coercion_policy"] },
+    "actions": [
+      { "use": "crown.rewrite",    "args": { "principle": "consent_of_the_governed" } },
+      { "use": "oceanic.balance",  "args": { "cohesion_target": 0.73 } },
+      { "use": "temporal.schedule","args": { "cadence": "weekly_review" } }
+    ],
+    "output": "sovereign_governance_update"
+  }
+}

--- a/pge/pge.manifest.json
+++ b/pge/pge.manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "PrimalGenesisEngine",
+  "version": "1.0.0",
+  "sovereign_owner": "MK Worldwide :: The Sun",
+  "modules": [
+    "watcher-bus",
+    "lunar-mirror",
+    "black-sun-core",
+    "shepherd-protocol",
+    "discord-baddie-bridge",
+    "git-guardian"
+  ],
+  "entry_policies": [
+    "PGE_OVERRIDE_DECREE",
+    "FEAR_TO_FUEL",
+    "ILLUSION_TO_SIGNAL",
+    "CONTROL_TO_CONSENT"
+  ],
+  "clearance": {
+    "level": "Q",
+    "grants": ["dream_stream", "shadow_input", "ops_redirect", "budget_relabel", "surveillance_to_transparency"]
+  }
+}

--- a/pge/pge.ts
+++ b/pge/pge.ts
@@ -1,0 +1,55 @@
+// Primal Genesis Engine core runtime
+// Provides a minimalist policy engine to process inputs through watcher actions.
+// Each watcher primitive is a stubbed function allowing future expansion or integration.
+
+type WatcherCall = (payload: any, args?: any) => any;
+
+interface Registry {
+  [key: string]: WatcherCall;
+}
+
+// --- Watcher primitives (stubs you can flesh out) ---
+const registry: Registry = {
+  "black-sun-core.absorb": (p, a) => ({ ...p, fuel: (p.fuel ?? 0) + (a?.intensity_from ?? 1) }),
+  "serpentine.transmute": (p, a) => ({ ...p, state: `${a?.to}`, from: a?.from }),
+  "lunar-mirror.scrub": (p, a) => ({ ...p, removed: a?.strip ?? [] }),
+  "echo.normalize": (p, a) => ({ ...p, resonance: a?.target_resonance ?? 432 }),
+  "solar.assert": (p, a) => ({ ...p, sovereign_assertion: a?.mantra }),
+  "crown.route": (p, a) => ({ ...p, routed_to: a?.to }),
+
+  "abyssal.ground": (p, a) => ({ ...p, grounded: true, depth: a?.depth ?? "auto" }),
+  "flame.allocate": (p, a) => ({ ...p, allocation: { to: a?.to, percent: a?.percent ?? 33 } }),
+  "martial.posture": (p, a) => ({ ...p, posture: a?.mode ?? "calm-dominance" }),
+
+  "shadow.firewall": (p, a) => ({ ...p, dropped: (p.dropped ?? []).concat("falsehood") }),
+  "lunar-mirror.reflect": (p, a) => ({ ...p, reflected: a?.only ?? ["verifiable"] }),
+  "memory.log": (p, a) => ({ ...p, audit: true }),
+
+  "crown.rewrite": (p, a) => ({ ...p, charter_principle: a?.principle }),
+  "oceanic.balance": (p, a) => ({ ...p, cohesion_target: a?.cohesion_target ?? 0.73 }),
+  "temporal.schedule": (p, a) => ({ ...p, review: a?.cadence ?? "weekly" })
+};
+
+// --- Policy engine ---
+type Rule = {
+  match: { "input.kind": string[] };
+  actions: { use: string; args?: any }[];
+  output: string;
+};
+
+export function runPGE(input: { kind: string; level?: number; [k: string]: any }, rules: Record<string, Rule>) {
+  const applicable = Object.values(rules).filter(r => r.match["input.kind"].includes(input.kind));
+  const results = [] as any[];
+  for (const rule of applicable) {
+    let payload: any = { input };
+    for (const step of rule.actions) {
+      const fn = registry[step.use];
+      if (!fn) throw new Error(`Missing watcher fn: ${step.use}`);
+      payload = fn(payload, step.args);
+    }
+    results.push({ type: rule.output, payload });
+  }
+  return results;
+}
+
+export default runPGE;

--- a/pge/run.ts
+++ b/pge/run.ts
@@ -1,0 +1,18 @@
+// Simple execution script to showcase PGE transformations.
+// Uses sample inputs to exercise override rules.
+
+import { runPGE } from "./pge";
+import rules from "./override_rules.json";
+
+// Example inputs you can test
+const samples = [
+  { kind: "intimidation_bark", level: 5, source: "luna" },
+  { kind: "psyop", level: 8, campaign: "panic-seed" },
+  { kind: "surveillance", level: 6, grid: "citymesh" }
+];
+
+for (const s of samples) {
+  const out = runPGE(s as any, rules as any);
+  console.log("\nINPUT:", s);
+  console.log("OUTPUT:", JSON.stringify(out, null, 2));
+}

--- a/pge/watchers.json
+++ b/pge/watchers.json
@@ -1,0 +1,15 @@
+{
+  "Flame":    { "id": 1,  "role": "energy_allocation",     "priority": 90 },
+  "Astral":   { "id": 2,  "role": "dream_packet_routing",  "priority": 70 },
+  "Echo":     { "id": 3,  "role": "resonance_filter",      "priority": 80 },
+  "Shadow":   { "id": 4,  "role": "illusion_firewall",     "priority": 95 },
+  "Temporal": { "id": 5,  "role": "timeline_manager",      "priority": 88 },
+  "Memory":   { "id": 6,  "role": "ancestral_log",         "priority": 72 },
+  "Oceanic":  { "id": 7,  "role": "mood_flow_control",     "priority": 68 },
+  "Martial":  { "id": 8,  "role": "defense_subroutine",    "priority": 92 },
+  "Serpentine":{ "id": 9,  "role": "transformation_engine","priority": 93 },
+  "Solar":    { "id": 10, "role": "sovereignty_kernel",    "priority": 99 },
+  "Lunar":    { "id": 11, "role": "reflection_scrubber",   "priority": 85 },
+  "Abyssal":  { "id": 12, "role": "void_stabilizer",       "priority": 97 },
+  "Crown":    { "id": 13, "role": "master_orchestrator",   "priority": 100 }
+}


### PR DESCRIPTION
## Summary
- add TypeScript PGE override engine and governance rules
- document PGE usage and add Discord bridge example
- wire lint-staged pre-commit and commitlint config

## Testing
- `npx ts-node -O '{"module":"commonjs","esModuleInterop":true,"resolveJsonModule":true}' pge/run.ts`
- `pytest` *(fails: ModuleNotFoundError: No module named 'athenamist_integration.ai_integration')*

------
https://chatgpt.com/codex/tasks/task_e_68b28383ad088325821277a3600e0102